### PR TITLE
Prevent profile overwrite

### DIFF
--- a/bin/install.ps1
+++ b/bin/install.ps1
@@ -5,7 +5,8 @@ if(!(test-path $profile)) {
 }
 if((gc $profile | sls 'pshazz') -eq $null) {
 	write-host 'adding pshazz to your powershell profile'
-	(gc $profile -raw) + "`r`ntry { `$null = gcm pshazz -ea stop; pshazz init 'default' } catch { }`r`n" > $profile
+	$new_profile = (gc $profile -raw) + "`r`ntry { `$null = gcm pshazz -ea stop; pshazz init 'default' } catch { }`r`n"
+    $new_profile > $profile
 } else {
 	write-host 'it looks like pshazz is already in your powershell profile, skipping'
 }


### PR DESCRIPTION
I was following along with your Scoop demo (very nice BTW!), when I noticed that the pshazz install blasted my powershell profile. Currently, it deletes the contents of the profile and just leaves the line "try { `$null = gcm pshazz -ea stop; pshazz init 'default' } catch { }".

Assigning the new profile to a variable prior to writing it to $profile seems to resolve the issue.

Also, apologies for the line endings / spacing, I tried a couple times, but couldn't get them quite right for some reason.
