### PR TITLE
resetcolor on backgroundcolor as well

### DIFF
--- a/plugins/resetcolor.ps1
+++ b/plugins/resetcolor.ps1
@@ -1,11 +1,16 @@
 # resets the console foreground color if a program changes it
 function pshazz:resetcolor:init {
 	$global:pshazz:resetcolor:fg = $host.ui.rawui.foregroundcolor
+	$global:pshazz:resetcolor:bg = $host.ui.rawui.backgroundcolor
 }
 
 function global:pshazz:resetcolor:prompt {
 	$fg = $global:pshazz:resetcolor:fg
 	if($host.ui.rawui.foregroundcolor -ne $fg) {
 		$host.ui.rawui.foregroundcolor = $fg
+	}
+	$bg = $global:pshazz:resetcolor:bg
+	if($host.ui.rawui.backgroundcolor -ne $bg) {
+		$host.ui.rawui.backgroundcolor = $bg
 	}
 }


### PR DESCRIPTION
There are some programs that modify the background color as well (for example, `npm` errors and warnings), so it would be great if `resetcolor` also checked background color changes.
