### PR TITLE
Replace `rm` alias in source code and added `-force` to removing aliases

### DIFF
--- a/libexec/pshazz-rm.ps1
+++ b/libexec/pshazz-rm.ps1
@@ -10,7 +10,7 @@ if(!$name) { "<name> is required"; my_usage; exit 1}
 
 $path = "$user_themedir\$name.json"
 if(test-path $path) {
-	rm $path > $null
+	Remove-Item $path > $null
 	"removed '$name'"
 } else {
 	"pshazz: '$name' custom theme not found. use 'pshazz list' to see themes."; exit 1

--- a/plugins/aliases.ps1
+++ b/plugins/aliases.ps1
@@ -13,7 +13,7 @@ function pshazz:aliases:init {
 		# may need to execute the rm many times in parent scopes until really removed
 		# (set-alias -option allscope copies the alias to child scopes)
 		while(test-path "alias:$_") {
-			rm "alias:\$_"
+			Remove-Item "alias:\$_" -force
 		}
 	}
 


### PR DESCRIPTION
1. Replaced `rm` with `Remove-Item` to allow assigning another command to `rm`
2. Add `-force` option to removing aliases (`Remove-Item "alias:\$_" -force`) to allow assigning custom aliases to default global/constant ones (e.g. to `gl`)