### PR TITLE
fix throw exception when user_themedir doesn't exist

### DIFF
--- a/libexec/pshazz-list.ps1
+++ b/libexec/pshazz-list.ps1
@@ -8,8 +8,12 @@ function list_themes($dir) {
 	gci "$dir" "*.json" |% { "  $($_.name -replace '.json$', '')" }
 }
 
-"Custom themes:"
-list_themes $user_themedir
-
 "Default themes:"
 list_themes $themedir
+
+"Custom themes:"
+if(Test-Path $user_themedir) {
+	list_themes $user_themedir
+} else {
+    ""
+}


### PR DESCRIPTION
`pshazz list` cmd will throw exception if `$user_themedir` doesn't exist. The `$user_themedir` wouldn't be created unless a user create it or type `pshazz new <name>` cmd, this fix it, user no need to create `$user_themedir`. And it put `Default themes` on `Custom themes`, which should looks better.

##### before:
```sh
~ $ pshazz list
Custom themes:
gci : Cannot find path 'C:\Users\hanabi\pshazz' because it does not exist.
At C:\Users\hanabi\AppData\Local\scoop\apps\pshazz\0.2016.03.24.1\libexec\pshaz
z-list.ps1:8 char:2
+     gci "$dir" "*.json" |% { "  $($_.name -replace '.json$', '')" }
+     ~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (C:\Users\hanabi\pshazz:String)
   [Get-ChildItem], ItemNotFoundException
    + FullyQualifiedErrorId : PathNotFound,Microsoft.PowerShell.Commands.GetCh
   ildItemCommand

Default themes:
  awan
  default
  keepprompt
  lukes
  microsoft
  msys
  myty
  tonic
  xpando
~ $
```

##### after:
```sh
~ $ pshazz list
Default themes:
  awan
  default
  keepprompt
  lukes
  microsoft
  msys
  myty
  tonic
  xpando
Custom themes:

~ $
```