### PR TITLE
add ssh host completions based on ssh config file

### DIFF
--- a/libexec/ssh-complete.ps1
+++ b/libexec/ssh-complete.ps1
@@ -1,0 +1,28 @@
+param($fragment) # everything after ^ssh\s*
+
+function sshHosts($filter) {
+	$config_file = "$env:USERPROFILE\.ssh\config"
+
+	$hosts = @()
+	Get-Content $config_file | where {$_ -like "Host *"} | % {
+		$hosts += $_.Split(" ") | Select-Object -Skip 1 | Where {$_ -like "$filter*"}
+	}
+
+	return $hosts
+}
+
+switch -regex ($fragment) {
+
+	# Handles ssh user@<host>
+	"^(?<user>\w+)@(?<cmd>\S*)$" {
+		sshHosts $matches['cmd'] | % {
+			return "$($matches['user'])@$_"
+		}
+	}
+
+	# Handles ssh <host>
+	"^(?<cmd>\S*)$" {
+		sshHosts $matches['cmd']
+	}
+
+}

--- a/plugins/ssh.ps1
+++ b/plugins/ssh.ps1
@@ -63,4 +63,6 @@ function pshazz:ssh:init {
 	} elseif(!(agent_has_keys)) {
 		add_keys
 	}
+
+	$global:pshazz.completions.ssh = resolve-path "$psscriptroot\..\libexec\ssh-complete.ps1"
 }


### PR DESCRIPTION
Adds basic completion of ssh hosts based on the [configured hosts](http://nerderati.com/2011/03/17/simplify-your-life-with-an-ssh-config-file/) in `.ssh/config`