### PR TITLE
Prompt: display more information for git on the branch name

### DIFF
--- a/lib/prompt.ps1
+++ b/lib/prompt.ps1
@@ -42,6 +42,24 @@ function global:pshazz_time {
 	return (get-date -DisplayHint time -format T)
 }
 
+# Based on posh-git
+function global:pshazz_local_or_parent_path($path) {
+	$check_in = Get-Item -Force .
+	if ($check_in.PSProvider.Name -ne 'FileSystem') {
+		return $null
+	}
+	while ($check_in -ne $NULL) {
+		$path_to_test = [System.IO.Path]::Combine($check_in.fullname, $path)
+		if (Test-Path -LiteralPath $path_to_test) {
+			return $check_in.fullname
+		} else {
+			$check_in = $check_in.parent
+		}
+	}
+	return $null
+}
+
+
 function global:pshazz_write_prompt($prompt, $vars) {
 	$vars.keys | % { set-variable $_ $vars[$_] }
 	function eval($str) {

--- a/plugins/git.ps1
+++ b/plugins/git.ps1
@@ -43,23 +43,6 @@ function pshazz:git:init {
 }
 
 # Based on posh-git
-function global:pshazz:git:local_or_parent_path($path) {
-	$check_in = Get-Item -Force .
-	if ($check_in.PSProvider.Name -ne 'FileSystem') {
-		return $null
-	}
-	while ($check_in -ne $NULL) {
-		$path_to_test = [System.IO.Path]::Combine($check_in.fullname, $path)
-		if (Test-Path -LiteralPath $path_to_test) {
-			return $check_in.fullname
-		} else {
-			$check_in = $check_in.parent
-		}
-	}
-	return $null
-}
-
-# Based on posh-git
 function global:pshazz:git:git_branch($git_dir) {
 	$r = ''; $b = ''; $c = ''
 	if (Test-Path $git_dir\rebase-merge\interactive) {
@@ -105,7 +88,7 @@ function global:pshazz:git:git_branch($git_dir) {
 function global:pshazz:git:prompt {
 	$vars = $global:pshazz.prompt_vars
 
-	$git_root = pshazz:git:local_or_parent_path .git
+	$git_root = pshazz_local_or_parent_path .git
 
 	if ($git_root) {
 

--- a/plugins/git.ps1
+++ b/plugins/git.ps1
@@ -1,4 +1,4 @@
-﻿try { gcm git -ea stop > $null } catch { return }
+﻿try { Get-Command git -ea stop > $null } catch { return }
 
 function pshazz:git:init {
 	$git = $global:pshazz.theme.git
@@ -42,11 +42,73 @@ function pshazz:git:init {
 	$global:pshazz.completions.git = resolve-path "$psscriptroot\..\libexec\git-complete.ps1"
 }
 
+# Based on posh-git
+function global:pshazz:git:local_or_parent_path($path) {
+	$check_in = Get-Item -Force .
+	if ($check_in.PSProvider.Name -ne 'FileSystem') {
+		return $null
+	}
+	while ($check_in -ne $NULL) {
+		$path_to_test = [System.IO.Path]::Combine($check_in.fullname, $path)
+		if (Test-Path -LiteralPath $path_to_test) {
+			return $check_in.fullname
+		} else {
+			$check_in = $check_in.parent
+		}
+	}
+	return $null
+}
+
+# Based on posh-git
+function global:pshazz:git:git_branch($git_dir) {
+	$r = ''; $b = ''; $c = ''
+	if (Test-Path $git_dir\rebase-merge\interactive) {
+		$r = '|REBASE-i'
+		$b = "$(Get-Content $git_dir\rebase-merge\head-name)"
+	} elseif (Test-Path $git_dir\rebase-merge) {
+		$r = '|REBASE-m'
+		$b = "$(Get-Content $git_dir\rebase-merge\head-name)"
+	} else {
+		if (Test-Path $git_dir\rebase-apply) {
+			if (Test-Path $git_dir\rebase-apply\rebasing) {
+				$r = '|REBASE'
+			} elseif (Test-Path $git_dir\rebase-apply\applying) {
+				$r = '|AM'
+			} else {
+				$r = '|AM/REBASE'
+			}
+		} elseif (Test-Path $git_dir\MERGE_HEAD) {
+			$r = '|MERGING'
+		} elseif (Test-Path $git_dir\CHERRY_PICK_HEAD) {
+			$r = '|CHERRY-PICKING'
+		} elseif (Test-Path $git_dir\BISECT_LOG) {
+			$r = '|BISECTING'
+		}
+
+		try { $b = git symbolic-ref HEAD } catch { }
+		if (-not $b) {
+			try { $b = git rev-parse --short HEAD } catch { }
+		}
+	}
+
+	if ('true' -eq $(git rev-parse --is-inside-git-dir 2>$null)) {
+		if ('true' -eq $(git rev-parse --is-bare-repository 2>$null)) {
+			$c = 'BARE:'
+		} else {
+			$b = 'GIT_DIR!'
+		}
+	}
+
+	return "$c$($b -replace 'refs/heads/','')$r"
+}
+
 function global:pshazz:git:prompt {
 	$vars = $global:pshazz.prompt_vars
 
-	try { $ref = git symbolic-ref HEAD } catch { }
-	if($ref) {
+	$git_root = pshazz:git:local_or_parent_path .git
+
+	if ($git_root) {
+
 		$vars.yes_git = ([char]0xe0b0);
 		$vars.git_local_state = ""
 		$vars.git_remote_state = ""
@@ -56,7 +118,7 @@ function global:pshazz:git:prompt {
 		$vars.git_lbracket = $global:pshazz.git.prompt_lbracket
 		$vars.git_rbracket = $global:pshazz.git.prompt_rbracket
 
-		$vars.git_branch = $ref -replace '^refs/heads/', '' # branch name
+		$vars.git_branch =  pshazz:git:git_branch (Join-Path $git_root ".git")
 
 		try { $status = git status --porcelain } catch { }
 		try { $stash = git rev-parse --verify --quiet refs/stash } catch { }
@@ -68,7 +130,7 @@ function global:pshazz:git:prompt {
 		if($status) {
 			$vars.git_dirty = $global:pshazz.git.prompt_dirty
 
-			$status | forEach {
+			$status | ForEach-Object {
 				$item_array = $_.Split(" ")
 
 				if ($_.Substring(0, 2) -eq "??") {


### PR DESCRIPTION
Note: this is the same as #52 - I just realized I wasn't using git right.

This patch display more information close to the branch name in the prompt for git repositories:
* display the short sha if htere is no branch name
* display some additional information when: rebasing, merging, cherry-picking, bisecting...
* all the rest is the same as before

Screenshot before:
![2017-06-24 21_54_59-windows powershell](https://user-images.githubusercontent.com/469305/27511589-f3aec6c8-5927-11e7-872c-96f6652d883e.png)

And the same after:
![2017-06-24 21_55_04-windows powershell](https://user-images.githubusercontent.com/469305/27511593-fcac583a-5927-11e7-9189-7d8493ac962f.png)

