### PR TITLE
Make pshazz home agnostic.

### DIFF
--- a/lib/config.ps1
+++ b/lib/config.ps1
@@ -1,4 +1,4 @@
-﻿$cfgpath = $env:PSHAZZ_CFG, "~/.pshazz" | select -first 1
+﻿$cfgpath = $env:PSHAZZ_CFG, "$env:USERPROFILE/.pshazz" | select -first 1
 
 function to_hashtable($obj) {
 	$ht = @{}

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -3,7 +3,8 @@
 }
 
 function friendly_path($path) {
-	$h = $home; if(!$h.endswith('\')) { $h += '\' }
+	$h = (Get-PsProvider 'FileSystem').home
+	if(!$h.endswith('\')) { $h += '\' }
 	return "$path" -replace ([regex]::escape($h)), "~\"
 }
 

--- a/lib/prompt.ps1
+++ b/lib/prompt.ps1
@@ -3,7 +3,8 @@
 }
 
 function global:pshazz_dir {
-	if($pwd -like $home) { return '~' }
+	$h = (Get-PsProvider 'FileSystem').home
+	if($pwd -like $h) { return '~' }
 
 	$dir = split-path $pwd -leaf
 	if($dir -imatch '[a-z]:\\') { return '\' }
@@ -11,14 +12,20 @@ function global:pshazz_dir {
 }
 
 function global:pshazz_two_dir {
-	if($pwd -like $home) { return '~' }
+	$h = (Get-PsProvider 'FileSystem').home
+	if($pwd -like $h) { return '~' }
 
 	$dir = split-path $pwd -leaf
 	$parent_pwd = split-path $pwd -parent
 	if($dir -imatch '[a-z]:\\') { return '\' }
 
 	if($parent_pwd) {
-		$parent = split-path $parent_pwd -leaf
+		if($parent_pwd -like $h)
+		{
+			$parent = '~'
+		} else {
+			$parent = split-path $parent_pwd -leaf
+		}
 
 		if( $parent -imatch '[a-z]:\\') {
 			$dir = "\$dir"
@@ -31,7 +38,7 @@ function global:pshazz_two_dir {
 }
 
 function global:pshazz_path {
-	return $pwd -replace [regex]::escape($home), "~"
+	return $pwd -replace [regex]::escape((Get-PsProvider 'FileSystem').home), "~"
 }
 
 function global:pshazz_rightarrow {

--- a/lib/theme.ps1
+++ b/lib/theme.ps1
@@ -1,5 +1,5 @@
 ﻿$themedir = friendly_path (fullpath "$psscriptroot\..\themes")
-$user_themedir = $env:PSHAZZ_THEMES, "~/pshazz" | select -first 1
+$user_themedir = $env:PSHAZZ_THEMES, "$env:USERPROFILE/pshazz" | select -first 1
 
 function theme($name) {
 	$path = find_path $name

--- a/libexec/pshazz-init.ps1
+++ b/libexec/pshazz-init.ps1
@@ -2,7 +2,7 @@
 # Summary: Initialize pshazz
 # Help: Usually this is called from your PS profile.
 #
-# When initializing, pshazz will use the theme configured in ~/.pshazz
+# When initializing, pshazz will use the theme configured in $env:USERPROFILE/.pshazz
 # or otherwise revert to the default theme.
 . "$psscriptroot\..\lib\core.ps1"
 . "$psscriptroot\..\lib\help.ps1"

--- a/plugins/ssh.ps1
+++ b/plugins/ssh.ps1
@@ -1,9 +1,9 @@
 ﻿# based on script from here:
 # https://help.github.com/articles/working-with-ssh-key-passphrases#platform-windows
 
-# Note: ~/.ssh/environment should not be used, as it
+# Note: $env:USERPROFILE/.ssh/environment should not be used, as it
 #       already has a different purpose in SSH.
-$envfile="~/.ssh/agent.env.ps1"
+$envfile="$env:USERPROFILE/.ssh/agent.env.ps1"
 
 try { gcm ssh-agent -ea stop > $null } catch { return }
 
@@ -38,7 +38,7 @@ function agent_start {
 	$script = $script -creplace '([A-Z_]+)=([^;]+).*', '$$env:$1="$2"' `
 		-creplace 'echo ([^;]+);', 'echo "$1"'
 
-	if(!(test-path "~/.ssh")) { mkdir "~/.ssh" > $null }
+	if(!(test-path "$env:USERPROFILE/.ssh")) { mkdir "$env:USERPROFILE/.ssh" > $null }
 
 	$script > $envfile
 	. $envfile > $null

--- a/plugins/z.psm1
+++ b/plugins/z.psm1
@@ -80,7 +80,8 @@ function Update-NavigationHistory {
 	)
 
 	# Abort if we got $HOME
-	if ($Path -eq $HOME) {
+	$h = (Get-PsProvider 'FileSystem').home
+	if ($Path -eq $h) {
 		return
 	}
 


### PR DESCRIPTION
Rather use (Get-PsProvider 'FileSystem').home, in case the user
is not working in $Env:USERPROFILE, but want to keep using ~.

I'm actually in this case:
* I'm working in C:\nicolas
* $home is in C:\Users\nicolas

I want to keep all dot files or settings files in $home, but use 
`cd ~` to got ot C:\nicolas