### PR TITLE
Add virtualenv plugin

### DIFF
--- a/plugins/virtualenv.ps1
+++ b/plugins/virtualenv.ps1
@@ -1,0 +1,20 @@
+# Plugin to display virtualenv in prompt
+
+function pshazz:virtualenv:init {
+	$virtualenv = $global:pshazz.theme.virtualenv
+
+	$global:pshazz.virtualenv = @{
+		prompt_lbracket = $virtualenv.prompt_lbracket;
+		prompt_rbracket = $virtualenv.prompt_rbracket;
+	}
+}
+
+function global:pshazz:virtualenv:prompt {
+	$vars = $global:pshazz.prompt_vars
+
+    if($env:VIRTUAL_ENV) {
+        $vars.virtualenv_lbracket = $global:pshazz.virtualenv.prompt_lbracket
+        $vars.virtualenv_rbracket = $global:pshazz.virtualenv.prompt_rbracket
+        $vars.virtualenv = (Get-Item $env:VIRTUAL_ENV).BaseName
+    }
+}


### PR DESCRIPTION
A tiny plugin to display [virtualenv](https://virtualenv.pypa.io/) in prompt.

Usage example:
https://github.com/h404bi/dotfiles/blob/master/src/pshazz/h404bi.json
``` json
{
	"plugins": [ "virtualenv" ],
	"prompt": [
		[ "darkgreen",   "", "$hostname" ],
		[ "darkcyan",    "", " $dir" ],
		[ "darkcyan",  "", " $virtualenv_lbracket$virtualenv"],
		[ "darkcyan",  "", "$virtualenv_rbracket"],
		[ "",            "", "`n$" ]
	],
	"virtualenv": {
		"prompt_lbracket": "[",
		"prompt_rbracket": "]"
	}
}
```

What it looks like:
![venv_demo](https://user-images.githubusercontent.com/5764917/38935595-4ea0b550-4351-11e8-8c80-b51e303ab788.jpg)

And please make a new release of pshazz for scoop if this pull request being merged.
