### PR TITLE
Feature: support user plugins directory

### DIFF
--- a/lib/plugin.ps1
+++ b/lib/plugin.ps1
@@ -1,10 +1,17 @@
 ﻿$plugindir = fullpath "$psscriptroot\..\plugins"
+$user_plugindir = $env:PSHAZZ_PLUGINS, "$env:USERPROFILE\pshazz\plugins" | Select-Object -first 1
 
 function plugin:init($name) {
-    $path = "$plugindir\$name.ps1"
+    # try user plugin dir first
+    $path = "$user_plugindir\$name.ps1"
     if(!(test-path $path)) {
-        "couldn't find plugin '$name' at $path"; return
+        # fallback to defaults
+        $path = "$plugindir\$name.ps1"
+        if(!(test-path $path)) {
+            Write-Warning "Couldn't find pshazz plugin '$name'."; return
+        }
     }
+
     . $path
 
     $initfn = "pshazz:$name`:init"


### PR DESCRIPTION
This helps differentiate core plugins from user plugins, allowing easier pshazz updates when using plugins that are not part of the main repository.  ------Original by @Deide 

Here I put `$userplugindir` first, which make sense when users want to override default plugins by their plugins stored in `$userplugindir`.