### PR TITLE
fix: Fixes an issue with null-length fileinfo objects

### DIFF
--- a/plugins/dircolors.ps1
+++ b/plugins/dircolors.ps1
@@ -1,4 +1,4 @@
-﻿function pshazz:dircolors:init {
+function pshazz:dircolors:init {
   if (!$global:pshazz_dircolors_iswrapped) {
 	wrap_command out-default -Process {
       if ($global:pshazz.theme.dircolors) {
@@ -64,6 +64,7 @@ function global:pshazz:dircolors:format_size($item) {
   if ($item -is [System.IO.DirectoryInfo]) {
     ""
   }
+  elseif (!$item.Exists) { "NA" }
   elseif ($item.Length -lt 1KB) {
     (($item.Length.ToString("n0")) + " B ")
   }


### PR DESCRIPTION
I was getting errors when displaying null-length (nonexistent) [system.io.fileinfo] objects. This fixes it.