### PR TITLE
Allow dynamic colors to enable e.g. Red prompt symbol '$' on errors

### DIFF
--- a/lib/prompt.ps1
+++ b/lib/prompt.ps1
@@ -110,6 +110,7 @@ function global:pshazz_write_prompt($prompt, $vars) {
 if (!$global:pshazz.theme.prompt) { return } # no prompt specified, keep existing
 
 function global:prompt {
+    $saved_lastoperationstatus = $? # status of win32 AND powershell command (False on interrupts)
     $saved_lastexitcode = $lastexitcode
 
     $global:pshazz.prompt_vars = @{

--- a/lib/prompt.ps1
+++ b/lib/prompt.ps1
@@ -99,7 +99,7 @@ function global:pshazz_write_prompt($prompt, $vars) {
         }
 
         if (![String]::IsNullOrWhiteSpace($str)) {
-            $fg = $_[0]; $bg = $_[1]
+            $fg = eval $_[0]; $bg = eval $_[1]
             if (!$fg) { $fg = $fg_default }
             if (!$bg) { $bg = $bg_default }
             Write-Host $str -NoNewline -ForegroundColor $fg -BackgroundColor $bg


### PR DESCRIPTION
I'd like to have a red `$` prompt symbol when the last operation status was an interruption/error (e.g. `$?` is `False`), this PR allows me to do that:
- via passing a function that outputs `Red` or `Green` (depending on the last op status) in the theme fg color field
- via adding a `$saved_lastoperationstatus=$?` variable in your prompt function to allo using this status in the function above