### PR TITLE
Make default aliases removable by users

### DIFF
--- a/plugins/aliases.ps1
+++ b/plugins/aliases.ps1
@@ -2,6 +2,9 @@
 # also adds some commonly used aliases
 # you can specify more aliases to add and remove in the theme under aliases.rm and aliases.add
 function pshazz:aliases:init {
+    # Add default aliases
+    Set-PAlias 'll' 'ls'
+
     # remove default/theme aliases
     $remove = @($global:pshazz.theme.aliases.rm) + ('curl', 'wget', 'r') | Where-Object { $_ } # theme overrides
     $remove | ForEach-Object {
@@ -11,9 +14,6 @@ function pshazz:aliases:init {
             Remove-Item "alias:\$_" -Force
         }
     }
-
-    # Add default aliases
-    Set-PAlias 'll' 'ls'
 
     # Theme aliases
     $global:pshazz.theme.aliases.add.psobject.Properties | Where-Object { $_ } | ForEach-Object {


### PR DESCRIPTION
This will make the default alias `ll` that is hardcoded in the aliases plugin removable and overwritable by users.

This enables, for example, to re-define `ll` to `ls -la` when using busybox or coreutils.