### PR TITLE
Make ssh plugin work with disabled native OpenSSH client and no admin rights.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,38 @@ Using [Scoop](http://scoop.sh):
 scoop install pshazz
 ```
 
-If you don't have Scoop installed, you can download a zip of this repository, and add `bin\pshazz.ps1` to your PATH.
+If you don't have Scoop installed, you can download a zip of this
+repository, and add `bin\pshazz.ps1` to your PATH.
+
+## The SSH helper
+When
+- you don't have admin rights
+- and, the native OpenSSH client is installed,
+- and the native ssh-agent service is disabled
+
+using the SSH helper is not straight forward and needs to be worked around.
+
+### Short version:
+
+- `scoop install openssh`
+- Add the scoop shims folder as the *first* `$PATH` item in your `$Profile`: `$env:PATH=$HOME+"\scoop\shims;"+$env:PATH`
+
+### Long version:
+
+It is possible to install openssh with `scoop install openssh` as a
+normal user and start the ssh-agent as a background process.
+
+However the path to `ssh.exe`, `ssh-agent.exe`, `ssh-add.exe` will be to the native OpenSSH client. This is unfortunate and cannot really be overridden since the PATH, coming from the system's `HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Environment` comes before the user specified PATH from `HKCU\Environment`. So the native ssh binaries are always usde and I have found no way to reliably override this automatically.
+
+To solve this issue you can add the following line to your `$Profile`. Which is in my case:
+
+```
+$HOME/Documents/WindowsPowerShell/Microsoft.PowerShell_profile.ps1
+```
+
+```
+$env:PATH=$HOME+"\scoop\shims;"+$env:PATH
+```
 
 ### On the shoulders of giants...
 Pshazz borrows heavily from:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ scoop install pshazz
 If you don't have Scoop installed, you can download a zip of this
 repository, and add `bin\pshazz.ps1` to your PATH.
 
-## The SSH helper
+### The SSH helper
 When
 - you don't have admin rights
 - and, the native OpenSSH client is installed,
@@ -28,17 +28,18 @@ When
 
 using the SSH helper is not straight forward and needs to be worked around.
 
-### Short version:
+#### Short version:
 
 - `scoop install openssh`
-- Add the scoop shims folder as the *first* `$PATH` item in your `$Profile`: `$env:PATH=$HOME+"\scoop\shims;"+$env:PATH`
+- Add the scoop shims folder as the *first* `$PATH` item in your `$Profile`: 
+  ```$env:PATH=$HOME+"\scoop\shims;"+$env:PATH```
 
-### Long version:
+#### Long version:
 
 It is possible to install openssh with `scoop install openssh` as a
 normal user and start the ssh-agent as a background process.
 
-However the path to `ssh.exe`, `ssh-agent.exe`, `ssh-add.exe` will be to the native OpenSSH client. This is unfortunate and cannot really be overridden since the PATH, coming from the system's `HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Environment` comes before the user specified PATH from `HKCU\Environment`. So the native ssh binaries are always usde and I have found no way to reliably override this automatically.
+However `ssh.exe`, `ssh-agent.exe`, `ssh-add.exe` will be the ones of the native OpenSSH client. The is because user path PATH, which included the scoop openssh binaries is always appended to the systems PATH. The OpenSSH binaries are found first and used. 
 
 To solve this issue you can add the following line to your `$Profile`. Which is in my case:
 
@@ -49,6 +50,11 @@ $HOME/Documents/WindowsPowerShell/Microsoft.PowerShell_profile.ps1
 ```
 $env:PATH=$HOME+"\scoop\shims;"+$env:PATH
 ```
+
+You can check these registry keys for the system and the user paths:
+- System: `req query "HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Environment" /v path` 
+- User: `req query "HKCU\Environment" /v path`
+
 
 ### On the shoulders of giants...
 Pshazz borrows heavily from:

--- a/themes/default.json
+++ b/themes/default.json
@@ -23,7 +23,7 @@
         "prompt_dirty": "*"
     },
     "ssh": {
-	"verbose": false,
-	"ignoreNativeAgent": false
+        "verbose": false,
+        "ignoreNativeAgent": false
     }
 }

--- a/themes/default.json
+++ b/themes/default.json
@@ -21,5 +21,9 @@
     },
     "hg": {
         "prompt_dirty": "*"
+    },
+    "ssh": {
+	"verbose": false,
+	"ignoreNativeAgent": false
     }
 }


### PR DESCRIPTION
Make the ssh plugin work with an installed but disabled native OpenSSH client.
- Add a configuration option to not try the native OpenSSH client
- start the ssh-agent.exe and capture the environment variables through an agent.env file
- save the SSH_AUTH_SOCK and SSH_AGENT_PID to the user environment so they can be picked up by other processes. This is required for using the git client in visual studio.
- update the Readme